### PR TITLE
Calling SS_Object instead of Object

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -2,18 +2,18 @@
 
 define('FRONTEND_ADMIN_DIR', basename(dirname(__FILE__)));
 
-Object::useCustomClass('Boolean', 'FrontEndBoolean', true);
-Object::useCustomClass('Enum', 'FrontEndEnum', true);
-//Object::useCustomClass('Image', 'FrontEndImage', true);
-Object::useCustomClass('HTMLText', 'FrontendEditorHTMLText', true);
-Object::useCustomClass('Text', 'FrontendEditorText', true);
-Object::useCustomClass('Varchar', 'FrontendEditorVarchar', true);
+SS_Object::useCustomClass('Boolean', 'FrontEndBoolean', true);
+SS_Object::useCustomClass('Enum', 'FrontEndEnum', true);
+//SS_Object::useCustomClass('Image', 'FrontEndImage', true);
+SS_Object::useCustomClass('HTMLText', 'FrontendEditorHTMLText', true);
+SS_Object::useCustomClass('Text', 'FrontendEditorText', true);
+SS_Object::useCustomClass('Varchar', 'FrontendEditorVarchar', true);
 
 //Image::add_extension('FrontEndImageExtension');
 
-Object::add_extension('Page_Controller', 'FrontendEditingControllerExtension');
-Object::add_extension('Page', 'FrontendAdminPageExtension');
+SS_Object::add_extension('Page_Controller', 'FrontendEditingControllerExtension');
+SS_Object::add_extension('Page', 'FrontendAdminPageExtension');
 
 if (class_exists("DynamicCacheExtension")) {
-    Object::add_extension('DynamicCache', 'FrontEndAdminDynamicCacheExtension');
+    SS_Object::add_extension('DynamicCache', 'FrontEndAdminDynamicCacheExtension');
 }

--- a/code/extensions/FrontendEditingControllerExtension.php
+++ b/code/extensions/FrontendEditingControllerExtension.php
@@ -32,7 +32,7 @@ class FrontendEditingControllerExtension extends Extension
 
         if ($canEdit) {
             // Enable front-end fly-out menu
-            // 
+            //
             //Flexslider imports easing, which breaks?
             Requirements::block('flexslider/javascript/jquery.easing.1.3.js');
 
@@ -148,7 +148,7 @@ class FrontendEditingControllerExtension extends Extension
     }
 }
 
-class FrontEndEditItem extends Object
+class FrontEndEditItem extends SS_Object
 {
     public $class;
     public $field;


### PR DESCRIPTION
Support for SilverStripe 3.7

https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-project-code

_SilverStripe 3.7 now supports PHP 7.2, which is exciting, but PHP 7.2 introduces an object keyword. To use it, you can replace any uses of Object with SS_Object in your own project code._